### PR TITLE
Update poe-client.js

### DIFF
--- a/src/poe-client.js
+++ b/src/poe-client.js
@@ -393,6 +393,17 @@ class PoeClient {
                 document
                     .querySelectorAll(".PageWithSidebarNavItem_label__WUzi5")[3]
                     .click();
+            } else if (
+                // Poe did some fuckery and broke the regular if/else statements, quick 'n dirty fix until Poe gets their shit together
+                document.querySelectorAll(
+                    ".SidebarSection_section__nmtML"
+                )[1].childNodes[0].childNodes[0].childNodes[1].innerText === "Your bots"
+            ) {
+                document
+                    .querySelectorAll(".SidebarSection_section__nmtML")[1]
+                    .childNodes[0]
+                    .childNodes[0]
+                    .click();
             } else {
                 document
                     .querySelectorAll(".PageWithSidebarNavItem_label__WUzi5")[2]


### PR DESCRIPTION
querySelectorAll at the start of getBotNames only returns 2 items, so the whole expression doesn't work

IDK if it'll get fixed, like ever, so I made my own (temp?) fix